### PR TITLE
Option to automatically retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Jobs
 ---------------
 This job class invokes a subcommand with arguments, run from a sandbox directory. In the
 event that the job lock is lost, the subprocess is forcibly killed. In the event that the
-subprocess exits with a non-zero status code, the job is failed and the last 1K of
-`stderr` and `stdout` are reported as the failure message.
+subprocess exits with a non-zero status code, the job is retried and the last 1K of
+`stderr` and `stdout` are reported as the failure message. To not automatically retry jobs
+whose subprocess has failed, use the option `"retry": false` in the job data. When in
+retry mode, an optional `"delay"` field can be provided in the job data, indicating the
+retry delay (in seconds).
 
 __NOTE: Because this allows a job to run an arbitrary command on a system, extreme care
 should be taken. The process running `qless-py-worker` should be a service user (with
@@ -28,7 +31,9 @@ The data is expected to be of the form:
 ```json
 {
     "command": "...",
-    "args": ["...", "...", ...]
+    "args": ["...", "...", ...],
+    # This is optional -- when present, should be false or true
+    "retry": false
 }
 ```
 

--- a/qless_util/jobs/__init__.py
+++ b/qless_util/jobs/__init__.py
@@ -37,7 +37,10 @@ class SubprocessJob(object):
                         'Stderr (last 1k): %s' % stderr[-1000:],
                         'Stdout (last 1k): %s' % stdout[-1000:]
                     ])
-                    job.fail(group, message)
+                    if job.data.get('retry', True):
+                        job.retry(job.data.get('delay', 0), group, message)
+                    else:
+                        job.fail(group, message)
                 else:
                     job.complete()
             finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ mock==1.3.0
 nose==1.3.7
 pbr==1.10.0
 python-termstyle==0.1.10
-qless-py==0.11.3
+qless-py==0.11.4
 redis==2.10.5
 rednose==1.1.1
 simplejson==3.10.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name                 = 'qless-util',
-    version              = '0.1.0',
+    version              = '0.1.1',
     description          = 'Qless utilities',
     long_description     = '''Utilities for qless.''',
     url                  = 'http://github.com/seomoz/qless-util-py',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires     = [
         'decorator',
         'hiredis',
+        'qless-py>=0.11.4',
         'redis',
         'six',
         'simplejson'


### PR DESCRIPTION
By default now, failed subprocesses will be retried. This can be disabled with `"retry": false` in the job data.

@tammybailey @lindseyreno